### PR TITLE
Fix `NaN` elo on user profiles.

### DIFF
--- a/website.js
+++ b/website.js
@@ -170,7 +170,7 @@ async function listen() {
       username: user.username,
       user_id: user.user_id,
       games_played: user.games_played,
-      elo: Math.round(user.logistic_mu),
+      elo: Math.round(user.elo),
       rank: await get_rank(user.elo),
       matches: [],
       pagination: generate_pagination(page_num, 1, nb_pages),


### PR DESCRIPTION
See #9 for details of the bug.

After some code and history inspection the `user` object on the changed line had access to a field `.elo` seen by the line following it afterwards.

I haven't checked but this should fix the `NaN` on the  user profiles since this was changed on 11e7aaa and `rank` was also defined there.

As a suggestion, maybe a typescript rework could be beneficial to catch these simple errors before they hit prod.

Fixes #9 