### PR TITLE
Fixed allPlayersReady bug when a player leaves

### DIFF
--- a/bancho.js
+++ b/bancho.js
@@ -57,7 +57,7 @@ async function try_get_player(display_username) {
       aim_pp: 10.0, acc_pp: 1.0, speed_pp: 1.0, overall_pp: 1.0,
       avg_ar: 8.0, avg_sr: 2.0,
       last_update_tms: 0,
-      readyState: "Not Ready",
+      readyState: 'Not Ready',
       games_played: 0, rank_text: 'Unranked',
     };
   }
@@ -488,18 +488,18 @@ class BanchoLobby extends EventEmitter {
 
             // Check if all players are ready if we are not playing
             if (!this.playing) {
-              var playerUsernames = Object.keys(this.players);
-              var notReadyFlag = false;
-              for(var i = 0; i < playerUsernames; i++) {
-                var tempPlayerUsername = playerUsernames[i];
-                if (this.players[tempPlayerUsername].readyState != "Ready") {
+              const playerUsernames = Object.keys(this.players);
+              let notReadyFlag = false;
+              for (let i = 0; i < playerUsernames; i++) {
+                const tempPlayerUsername = playerUsernames[i];
+                if (this.players[tempPlayerUsername].readyState != 'Ready') {
                   notReadyFlag = true;
                   break;
                 }
               }
 
               if (!notReadyFlag) {
-                this.emit('allPlayersReady')
+                this.emit('allPlayersReady');
               }
             }
           }

--- a/ranked.js
+++ b/ranked.js
@@ -321,6 +321,9 @@ async function init_lobby(lobby, settings) {
         }
         return;
       }
+
+      // Get settings to update players and their readyState
+      await lobby.send('!mp settings');
     } catch (err) {
       set_sentry_context(lobby, 'playerLeft');
       Sentry.setUser(player);


### PR DESCRIPTION
Fixed the bug that will not start the game if all players are ready and somebody left the lobby.

What I did was to add a `readyState` value to the `players` array in the `Lobby` object. This will be updated everytime we get a `!mp settings` reply from Bancho. If all players are ready after checking them all, and the game is not started yet, the `Lobby` object will emit a `allPlayersReady` event. Whenever a player leaves, the `!mp settings` command is sent,

This is the first time working with BanchoBot for me, so if there is any logic error in my code, please feel free to point it out. I was just hoping I could fix this small bug, and if not, give you guys an idea of how we could do it.

Please keep in mind I haven't tested this yet since I do not have a testing environment setup, but I was hoping testing could be done by one of the repo contributors and fix other bugs if they appear.