### PR TITLE
Fix command text by adding plural distinction

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -92,7 +92,7 @@ async function rank_command(msg, match, lobby) {
   if (rank_info.text == 'Unranked') {
     if (requested_username === msg.from) {
       const games_played = user ? user.games_played : 0;
-      await reply(msg.from, lobby, `You are unranked. Play ${5 - games_played} more games to get a rank!`);
+      await reply(msg.from, lobby, `You are unranked. Play ${5 - games_played} more game${games_played === 1 ? "" : "s"} to get a rank!`);
     } else {
       await reply(msg.from, lobby, `${requested_username} is unranked.`);
     }


### PR DESCRIPTION
Maybe this is an overly pedantic commit, but I noticed a player ask for his rank before being told to play "1 more games" to get his rank. This patch hopefully should make it say "1 more game" if there is only 1 game left to play, and "x more games" if there are more than 1.